### PR TITLE
Cleanup BookKeeper metadata service URI management.

### DIFF
--- a/blobit-core/pom.xml
+++ b/blobit-core/pom.xml
@@ -29,7 +29,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.bookkeeper</groupId>
-            <artifactId>bookkeeper-server-shaded</artifactId>
+            <artifactId>bookkeeper-server</artifactId>
             <version>${libs.bookkeeper}</version>  
             <exclusions>
                 <exclusion>

--- a/blobit-core/src/main/java/org/blobit/core/api/Configuration.java
+++ b/blobit-core/src/main/java/org/blobit/core/api/Configuration.java
@@ -64,6 +64,9 @@ public class Configuration {
     public static final String ZOOKEEPER_URL = "zookeeper.url";
     public static final String ZOOKEEPER_URL_DEFAULT = "localhost:2181";
 
+    public static final String BOOKKEEPER_ZK_LEDGERS_ROOT_PATH = "client.bookkeeper.zk.ledgers.root.path";
+    public static final String BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT = "/blobit-bk";
+
     public Configuration() {
         this.properties = new Properties();
     }
@@ -82,6 +85,10 @@ public class Configuration {
     public Configuration setProperty(String key, Object value) {
         properties.put(key, value);
         return this;
+    }
+    
+    public String getProperty(String key, String defaultValue) {
+        return properties.getProperty(key, defaultValue);
     }
 
     public String getType() {

--- a/blobit-core/src/main/java/org/blobit/core/cluster/BookKeeperBlobManager.java
+++ b/blobit-core/src/main/java/org/blobit/core/cluster/BookKeeperBlobManager.java
@@ -319,8 +319,12 @@ public class BookKeeperBlobManager implements AutoCloseable {
             clientConfiguration.setLedgerManagerFactoryClass(HierarchicalLedgerManagerFactory.class);
             clientConfiguration.setEnableDigestTypeAutodetection(true);
 
-            clientConfiguration.setZkLedgersRootPath(PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT);
-            clientConfiguration.setZkServers(configuration.getZookkeeperUrl());
+            String zkLedgersRootPath = configuration.getProperty(Configuration.BOOKKEEPER_ZK_LEDGERS_ROOT_PATH,
+                    Configuration.BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT);
+            String zkServers = configuration.getZookkeeperUrl();
+            String metadataServiceURI = "zk+null://" + zkServers.replace(",", ";") + zkLedgersRootPath;
+            LOG.log(Level.INFO, "BlobIt client is using BookKeeper metadataservice URI: {0}", metadataServiceURI);
+            clientConfiguration.setMetadataServiceUri(metadataServiceURI);
 
 //            clientConfiguration.setUseV2WireProtocol(true);
             for (String key : configuration.keys()) {

--- a/blobit-core/src/main/java/org/blobit/core/cluster/BookKeeperBlobManager.java
+++ b/blobit-core/src/main/java/org/blobit/core/cluster/BookKeeperBlobManager.java
@@ -69,8 +69,7 @@ import static org.blobit.core.cluster.BucketWriter.DUMMY_PWD;
 public class BookKeeperBlobManager implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(BookKeeperBlobManager.class.getName());
-    static final String PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT = "/blobit-bk";
-
+    
     private final HerdDBMetadataStorageManager metadataStorageManager;
     private final BookKeeper bookKeeper;
     final GenericKeyedObjectPool<String, BucketWriter> writers;

--- a/blobit-core/src/test/java/org/blobit/core/cluster/ZKTestEnv.java
+++ b/blobit-core/src/test/java/org/blobit/core/cluster/ZKTestEnv.java
@@ -20,7 +20,6 @@
 package org.blobit.core.cluster;
 
 import java.nio.file.Path;
-import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -30,6 +29,7 @@ import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.CodahaleMetricsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.bookkeeper.util.ReflectionUtils;
+import static org.blobit.core.api.Configuration.BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT;
 import org.blobit.core.util.TestUtils;
 import static org.blobit.core.util.TestUtils.NOOP;
 
@@ -57,7 +57,7 @@ public class ZKTestEnv implements AutoCloseable {
         conf.setZkServers("localhost:1282");
         conf.setLedgerDirNames(new String[]{targetDir.toAbsolutePath().toString()});
         conf.setLedgerManagerFactoryClass(HierarchicalLedgerManagerFactory.class);
-        conf.setZkLedgersRootPath(BookKeeperBlobManager.PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT);
+        conf.setZkLedgersRootPath(BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT);
         int numJournals = 1;
         String[] journals = new String[numJournals];
         for (int i = 0; i < journals.length; i++) {

--- a/blobit-services/src/main/java/blobit/server/EmbeddedBookie.java
+++ b/blobit-services/src/main/java/blobit/server/EmbeddedBookie.java
@@ -60,9 +60,12 @@ public class EmbeddedBookie implements AutoCloseable {
     public void start() throws Exception {
         org.apache.bookkeeper.conf.ServerConfiguration conf = new org.apache.bookkeeper.conf.ServerConfiguration();
         conf.setZkTimeout(configuration.getInt(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT_DEFAULT));
-        conf.setZkServers(configuration.getString(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS_DEFAULT));
-        conf.setZkLedgersRootPath(configuration.getString(ServerConfiguration.PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH,
-                ServerConfiguration.PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT));
+        String zkServers = configuration.getString(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS_DEFAULT);
+        String zkLedgersRootPath = configuration.getString(ServerConfiguration.PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH,
+                ServerConfiguration.PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH_DEFAULT);
+        String metadataServiceUri = "zk+null://" + zkServers.replace(",", ";") + "" + zkLedgersRootPath;
+        LOG.log(Level.INFO, "Embeeded Bookie will use metadataServiceUri: {0}", metadataServiceUri);
+        conf.setMetadataServiceUri(metadataServiceUri);
         conf.setStatisticsEnabled(true);
         conf.setProperty("codahaleStatsJmxEndpoint", "BlobIt_Bookie");
         conf.setStatsProviderClass(CodahaleMetricsProvider.class);

--- a/blobit-services/src/main/java/blobit/server/Server.java
+++ b/blobit-services/src/main/java/blobit/server/Server.java
@@ -45,7 +45,7 @@ public class Server {
         boolean startBookie = configuration.getBoolean(ServerConfiguration.PROPERTY_BOOKKEEPER_START,
                 ServerConfiguration.PROPERTY_BOOKKEEPER_START_DEFAULT);
 
-        if (startBookie && embeddedBookie != null) {
+        if (startBookie && embeddedBookie == null) {
             try {
                 Files.createDirectories(this.baseDirectory);
             } catch (IOException ignore) {

--- a/blobit-services/src/main/resources/conf/server.properties
+++ b/blobit-services/src/main/resources/conf/server.properties
@@ -16,6 +16,8 @@ server.bookkeeper.start=true
 # bookkeeper uses local hostname and this port to identify bookies
 server.bookkeeper.port=-1
 
+# Every line starting with bookie. will be sent to the Bookie configuration (after stripping the prefix)
+
 # by default we will not wait for fsync on journal of bookies, this is good for tests or if you have a good replication factor
 bookie.journalSyncData=false
-
+bookie.allowLoopback=true

--- a/blobit-services/src/test/java/blobit/server/SimpleClusterTest.java
+++ b/blobit-services/src/test/java/blobit/server/SimpleClusterTest.java
@@ -57,12 +57,17 @@ public class SimpleClusterTest {
 
                 props.put(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
                 props.put(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zookeeperServer.getConnectString());
+                props.put(ServerConfiguration.PROPERTY_BOOKKEEPER_ZK_LEDGERS_ROOT_PATH, "/custom-path");
 
                 props.put("herddb." + herddb.server.ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
-                props.put("herddb." + herddb.server.ServerConfiguration.PROPERTY_BOOKKEEPER_START, "true");
                 props.put("herddb." + herddb.server.ServerConfiguration.PROPERTY_MODE, herddb.server.ServerConfiguration.PROPERTY_MODE_CLUSTER);
-                props.put("herddb." + herddb.server.ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zookeeperServer.getConnectString());
+                
+                // client configuration of the BlobIt client started inside the server (For the HTTP API)
                 props.put(Configuration.ZOOKEEPER_URL, zookeeperServer.getConnectString());
+                props.put(Configuration.BOOKKEEPER_ZK_LEDGERS_ROOT_PATH, "/custom-path");
+                
+                props.put(ServerConfiguration.PROPERTY_BOOKKEEPER_START, "true");
+                props.put("bookie.allowLoopback","true");
                 try (FileOutputStream oo = new FileOutputStream(tmpConfFile)) {
                     props.store(oo, "");
                 }


### PR DESCRIPTION
Cleanup BookKeeper metadata service URI management.
Fix embedded bookie boot (it should start before HerdDB)
Clean up pom, use BookKeeper raw dependency (not 'shaded')