### PR TITLE
Make write flags configurable

### DIFF
--- a/blobit-cli/dependency-reduced-pom.xml
+++ b/blobit-cli/dependency-reduced-pom.xml
@@ -74,7 +74,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 </project>

--- a/blobit-cli/src/main/java/org/blobit/cli/CommandPut.java
+++ b/blobit-cli/src/main/java/org/blobit/cli/CommandPut.java
@@ -24,8 +24,16 @@ import com.beust.jcommander.Parameters;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.blobit.core.api.BucketHandle;
 import org.blobit.core.api.Configuration;
+import org.blobit.core.api.ObjectManagerException;
 import org.blobit.core.api.PutPromise;
 
 /**
@@ -38,20 +46,20 @@ public class CommandPut extends BucketCommand {
     @Parameter(names = "--name", description = "Name of the blob, default to the same name of the file to write")
     public String name;
 
-    @Parameter(names = "--checksum", description = "Create a checksum")
+    @Parameter(names = "--checksum", description = "Create a checksum", arity = 1)
     public boolean checksum = true;
 
-    @Parameter(names = "--deferred-sync", description = "Use DEFERRED_SYNC flag")
+    @Parameter(names = "--deferred-sync", description = "Use DEFERRED_SYNC flag", arity = 1)
     public boolean deferredSync = false;
 
-    @Parameter(names = "--in", description = "File to read", required = true)
+    @Parameter(names = "--in", description = "Local file or directory to write", required = true)
     public File file;
 
     @Parameter(names = "--max-entry-size", description = "Max extry size, in bytes, defaults to 65536")
     private int maxEntrySize = 65536;
 
     @Parameter(names = "--replication", description = "Replication factor, defaults to 1")
-    private int replication = 1;
+    public int replication = 1;
 
     public CommandPut(CommandContext main) {
         super(main);
@@ -67,22 +75,60 @@ public class CommandPut extends BucketCommand {
 
     @Override
     public void execute() throws Exception {
+        long _start = System.currentTimeMillis();
+        AtomicLong totalBytes = new AtomicLong();
+        AtomicInteger totalFiles = new AtomicInteger();
+        if (file.isFile()) {
+            System.out.println("PUT BUCKET '" + bucket + "' NAME '" + name + "' " + file.length() + " bytes (maxEntrySize " + maxEntrySize + " bytes, replicationFactor: " + replication + ", checksum:" + checksum + " deferredSync:" + deferredSync + ")");
+        } else if (file.isDirectory()) {
+            System.out.println("PUT BUCKET '" + bucket + "' DIRECTORY '" + file + "' (maxEntrySize " + maxEntrySize + " bytes, replicationFactor: " + replication + ", checksum:" + checksum + " deferredSync:" + deferredSync + ")");
+        } else {
+            throw new IOException("File " + file + " does not exists");
+        }
+
+        doWithClient(client -> {
+            BucketHandle bucketHandle = client.getBucket(bucket);
+            File theFile = file;
+            List<PutPromise> results = new ArrayList<>();
+            writeOrScan(theFile, name, bucketHandle, totalFiles, totalBytes, results);
+            // really wait for all of the operations to finish
+            for (PutPromise pp : results) {
+                pp.get();
+            }
+            long _stop = System.currentTimeMillis();
+            double speed = (totalBytes.get() * 1000) / (1024 * 1024.0 * (_stop - _start));
+            System.out.println(totalFiles + " OBJECTs " + (totalBytes.get() / (1024 * 1024)) + " MBs WRITTEN SUCCESSFULLY, " + speed + " MB/s");
+        });
+    }
+
+    private static void writeOrScan(File theFile, String name, BucketHandle bucketHandle,
+            AtomicInteger totalFiles, AtomicLong totalBytes, List<PutPromise> results) throws IOException, InterruptedException, ObjectManagerException {
+        if (theFile.isDirectory() && name == null) {
+            File[] children = theFile.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    writeOrScan(child, name, bucketHandle, totalFiles, totalBytes, results);
+                }
+            }
+        } else {
+            writeFile(theFile, name, bucketHandle, totalFiles, totalBytes, results);
+        }
+    }
+
+    private static void writeFile(File file, String name, BucketHandle bucketHandle,
+            AtomicInteger totalCount, AtomicLong totalWritten, List<PutPromise> results)
+            throws IOException, InterruptedException, ObjectManagerException {
         if (name == null || name.isEmpty()) {
             name = file.getName();
         }
-        long _start = System.currentTimeMillis();
-        System.out.println("PUT BUCKET '" + bucket + "' NAME '" + name + "' " + file.length() + " bytes (maxEntrySize " + maxEntrySize + " butes, replicationFactor: " + replication + ", checksum:" + checksum + " deferredSync:" + deferredSync + ")");
-        doWithClient(client -> {
-            try (InputStream ii = new BufferedInputStream(new FileInputStream(file))) {
-                PutPromise put = client.getBucket(bucket)
-                        .put(name, file.length(), ii);
-                System.out.println("PUT PROMISE: object id: '" + put.id + "'");
-                put.get();
-                long _stop = System.currentTimeMillis();
-                double speed = (file.length() * 1000 * 60 * 60.0) / (1024 * 1024.0 * (_stop - _start));
-                System.out.println("OBJECT WRITTEN SUCCESSFULLY, " + speed + " MB/h");
-            }
-        });
+        totalCount.incrementAndGet();
+        try (InputStream ii = new BufferedInputStream(new FileInputStream(file))) {
+            PutPromise put = bucketHandle
+                    .put(name, file.length(), ii);
+            System.out.println("PUT PROMISE: object id: '" + put.id + "' name: '" + name + "'");
+            results.add(put);
+            totalWritten.addAndGet(file.length());
+        }
     }
 
 }

--- a/blobit-core/src/main/java/org/blobit/core/api/Configuration.java
+++ b/blobit-core/src/main/java/org/blobit/core/api/Configuration.java
@@ -61,6 +61,12 @@ public class Configuration {
     public static final String MAX_READERS = "max.readers";
     public static final int MAX_READERS_DEFAULT = 100;
 
+    public static final String ENABLE_CHECKSUM = "enable.checksum";
+    public static final boolean ENABLE_CHECKSUM_DEFAULT = true;
+
+    public static final String DEFERRED_SYNC = "deferred.sync";
+    public static final boolean DEFERRED_SYNC_DEFAULT = false;
+
     public static final String ZOOKEEPER_URL = "zookeeper.url";
     public static final String ZOOKEEPER_URL_DEFAULT = "localhost:2181";
 
@@ -86,7 +92,7 @@ public class Configuration {
         properties.put(key, value);
         return this;
     }
-    
+
     public String getProperty(String key, String defaultValue) {
         return properties.getProperty(key, defaultValue);
     }
@@ -174,6 +180,24 @@ public class Configuration {
 
     public int getMaxReaders() {
         return Integer.parseInt(properties.getProperty(MAX_READERS, MAX_READERS_DEFAULT + ""));
+    }
+
+    public boolean isEnableChecksum() {
+        return Boolean.parseBoolean(properties.getProperty(ENABLE_CHECKSUM, ENABLE_CHECKSUM_DEFAULT + ""));
+    }
+
+    public Configuration setEnableCheckSum(boolean value) {
+        properties.put(ENABLE_CHECKSUM, value);
+        return this;
+    }
+
+    public boolean isDeferredSync() {
+        return Boolean.parseBoolean(properties.getProperty(DEFERRED_SYNC, DEFERRED_SYNC_DEFAULT + ""));
+    }
+
+    public Configuration setDeferredSync(boolean value) {
+        properties.put(DEFERRED_SYNC, value);
+        return this;
     }
 
     public Collection<String> keys() {

--- a/blobit-services/src/main/resources/bin/setenv.sh
+++ b/blobit-services/src/main/resources/bin/setenv.sh
@@ -1,7 +1,7 @@
 # Basic Environment and Java variables
 
 #JAVA_HOME=
-JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=1g  -Djava.util.logging.config.file=conf/logging.properties"
+JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=1g  -Djava.util.logging.config.file=conf/logging.properties"
 
 if [ -z "$JAVA_HOME" ]; then
   JAVA_PATH=`which java 2>/dev/null`


### PR DESCRIPTION
Make BK write flags configurable:
- use BK checksum (not useful if the application already does its own checksum)
- enable BK DEFERRED_SYNC writeflag

Enhance CLI "put" operation to handle these parameters and to copy an entire directory tree (for manual testing/benchmarking)