### PR TITLE
Fix/concurrent init tablespaces

### DIFF
--- a/blobit-core/src/main/java/org/blobit/core/cluster/HerdDBMetadataStorageManager.java
+++ b/blobit-core/src/main/java/org/blobit/core/cluster/HerdDBMetadataStorageManager.java
@@ -19,8 +19,6 @@
  */
 package org.blobit.core.cluster;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import herddb.model.TableSpace;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -36,13 +34,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.sql.DataSource;
+
 import org.blobit.core.api.BucketConfiguration;
 import org.blobit.core.api.BucketMetadata;
 import org.blobit.core.api.Configuration;
 import org.blobit.core.api.LedgerMetadata;
 import org.blobit.core.api.ObjectManagerException;
 import org.blobit.core.api.ObjectMetadata;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import herddb.model.TableSpace;
 
 /**
  * Stores metadata on HerdDB
@@ -190,8 +193,8 @@ public class HerdDBMetadataStorageManager {
 
     public void init() throws ObjectManagerException {
         try {
-            ensureTablespace(bucketsTablespace, bucketsTableSpacesReplicaCount);
-            ensureTable(bucketsTablespace, BUCKET_TABLE, CREATE_BUCKETS_TABLE);
+            ensureTablespace(bucketsTablespace, bucketsTableSpacesReplicaCount, false);
+            ensureTable(bucketsTablespace, BUCKET_TABLE, CREATE_BUCKETS_TABLE, false);
             reloadBuckets();
         } catch (SQLException err) {
             throw new ObjectManagerException(err);
@@ -442,21 +445,38 @@ public class HerdDBMetadataStorageManager {
     }
 
     private void ensureTablespace(String schema, int replicaCount) throws SQLException {
+        ensureTablespace(schema, replicaCount, true);
+    }
+
+    private void ensureTablespace(String schema, int replicaCount, boolean failOnConcurrentCreation)
+            throws SQLException {
         if (!useTablespaces || !manageTablespaces) {
             return;
         }
         try (Connection connection = datasource.getConnection()) {
             connection.setSchema(TableSpace.DEFAULT);
-            DatabaseMetaData metaData = connection.getMetaData();
-            boolean existTablespace;
-            try (ResultSet schemas = metaData.getSchemas(null, schema);) {
-                existTablespace = schemas.next();
-            }
+            final DatabaseMetaData metaData = connection.getMetaData();
+            boolean existTablespace = checkTablespaceExistence(schema, metaData);
             if (!existTablespace) {
                 try (Statement s = connection.createStatement();) {
                     s.executeUpdate(createTableSpaceStatement(schema, replicaCount));
+                } catch (SQLException e) {
+                    /* Check if a concurrent process already created the tablespace */
+                    if (failOnConcurrentCreation || !checkTablespaceExistence(schema, metaData)) {
+                        /*
+                         * We should fail on concurrent creation or creation failed and tablespace still
+                         * doesn't exists, throw original error
+                         */
+                        throw e;
+                    }
                 }
             }
+        }
+    }
+
+    private boolean checkTablespaceExistence(String schema, DatabaseMetaData metaData) throws SQLException {
+        try (ResultSet schemas = metaData.getSchemas(null, schema);) {
+            return schemas.next();
         }
     }
 
@@ -466,28 +486,43 @@ public class HerdDBMetadataStorageManager {
         }
         try (Connection connection = datasource.getConnection()) {
             connection.setSchema(bucketsTablespace);
-            DatabaseMetaData metaData = connection.getMetaData();
-            try (ResultSet schemas = metaData.getSchemas(null, schema);) {
-                return schemas.next();
-            }
+            final DatabaseMetaData metaData = connection.getMetaData();
+            return checkTablespaceExistence(schema, metaData);
         }
     }
 
     private void ensureTable(String schema, String name, String createSql) throws SQLException {
+        ensureTable(schema, name, createSql, true);
+    }
+
+    private void ensureTable(String schema, String name, String createSql, boolean failOnConcurrentCreation)
+            throws SQLException {
         try (Connection connection = datasource.getConnection()) {
             if (useTablespaces) {
                 connection.setSchema(schema);
             }
-            DatabaseMetaData metaData = connection.getMetaData();
-            boolean existTable;
-            try (ResultSet rs = metaData.getTables(null, null, name, null)) {
-                existTable = rs.next();
-            }
+            final DatabaseMetaData metaData = connection.getMetaData();
+            boolean existTable = checkTableExistence(name, metaData);
             if (!existTable) {
                 try (Statement s = connection.createStatement();) {
                     s.executeUpdate(createSql);
+                } catch (SQLException e) {
+                    /* Check if a concurrent process already created the table */
+                    if (failOnConcurrentCreation || !checkTableExistence(name, metaData)) {
+                        /*
+                         * We should fail on concurrent creation or creation failed and table still
+                         * doesn't exists, throw original error
+                         */
+                        throw e;
+                    }
                 }
             }
+        }
+    }
+
+    private boolean checkTableExistence(String table, DatabaseMetaData metaData) throws SQLException {
+        try (ResultSet rs = metaData.getTables(null, null, table, null)) {
+            return rs.next();
         }
     }
 

--- a/blobit-core/src/main/java/org/blobit/core/cluster/HerdDBMetadataStorageManager.java
+++ b/blobit-core/src/main/java/org/blobit/core/cluster/HerdDBMetadataStorageManager.java
@@ -19,6 +19,8 @@
  */
 package org.blobit.core.cluster;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import herddb.model.TableSpace;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -34,18 +36,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.sql.DataSource;
-
 import org.blobit.core.api.BucketConfiguration;
 import org.blobit.core.api.BucketMetadata;
 import org.blobit.core.api.Configuration;
 import org.blobit.core.api.LedgerMetadata;
 import org.blobit.core.api.ObjectManagerException;
 import org.blobit.core.api.ObjectMetadata;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import herddb.model.TableSpace;
 
 /**
  * Stores metadata on HerdDB


### PR DESCRIPTION
In clustered setup tablespace existence enforce can fail due to concurrent creations attempts

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)