### PR TITLE
Add explict dependency for slf4j

### DIFF
--- a/blobit-cli/pom.xml
+++ b/blobit-cli/pom.xml
@@ -19,6 +19,18 @@
             <artifactId>jcommander</artifactId>
             <version>${libs.jcommmander}</version>
         </dependency>
+        <dependency>
+            <!-- not used directly, but by dependecies -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${libs.slf4j}</version>            
+        </dependency>
+        <dependency>
+            <!-- not used directly, but by dependecies -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${libs.slf4j}</version>            
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/blobit-services/pom.xml
+++ b/blobit-services/pom.xml
@@ -63,6 +63,18 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <!-- not used directly, but by dependecies -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${libs.slf4j}</version>            
+        </dependency>
+        <dependency>
+            <!-- not used directly, but by dependecies -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${libs.slf4j}</version>            
+        </dependency>
         
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <libs.jcommmander>1.72</libs.jcommmander>
         <libs.spotbugsannotations>3.1.8</libs.spotbugsannotations>
         <libs.spotbugsmaven>3.1.12</libs.spotbugsmaven>        
+        <libs.slf4j>1.7.25</libs.slf4j>        
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
In #24 I have removed every impl of slf4j but in the "CLI" and in the "services" modules we need one implementation.