### PR TITLE
Change default blobit tablespace to lowercase

### DIFF
--- a/blobit-core/src/main/java/org/blobit/core/api/Configuration.java
+++ b/blobit-core/src/main/java/org/blobit/core/api/Configuration.java
@@ -44,7 +44,7 @@ public class Configuration {
     public static final long LEADER_INACTIVITY_TIME_DEFAULT = 0;
 
     public static final String BUCKETS_TABLESPACE = "buckets.tablespace";
-    public static final String BUCKETS_TABLESPACE_DEFAULT = "BUCKETS";
+    public static final String BUCKETS_TABLESPACE_DEFAULT = "buckets";
 
     public static final String USE_TABLESPACES = "usetablespaces";
     public static final String USE_TABLESPACES_DEFAULT = "true";


### PR DESCRIPTION
This patch change default tablespace from "BUCKETS" to "buckets".
This resolves tablespace issues actually existing with herddb 0.14.0-SNAPSHOT