### PR TITLE
Fix typo in offset parameter

### DIFF
--- a/blobit-core/src/main/java/org/blobit/core/api/BucketHandle.java
+++ b/blobit-core/src/main/java/org/blobit/core/api/BucketHandle.java
@@ -157,7 +157,7 @@ public interface BucketHandle {
      */
     NamedObjectDownloadPromise downloadByName(String name,
             Consumer<Long> lengthCallback,
-            OutputStream output, int offset,
+            OutputStream output, long offset,
             long length);
 
     /**

--- a/blobit-core/src/main/java/org/blobit/core/cluster/ClusterObjectManager.java
+++ b/blobit-core/src/main/java/org/blobit/core/cluster/ClusterObjectManager.java
@@ -219,7 +219,7 @@ public class ClusterObjectManager implements ObjectManager {
         public NamedObjectDownloadPromise downloadByName(String name,
                 Consumer<Long> lengthCallback,
                 OutputStream output,
-                int offset, long length) {
+                long offset, long length) {
             List<String> ids = null;
             try {
                 ids = metadataManager.lookupObjectByName(bucketId, name);

--- a/blobit-core/src/main/java/org/blobit/core/mem/LocalManager.java
+++ b/blobit-core/src/main/java/org/blobit/core/mem/LocalManager.java
@@ -382,7 +382,7 @@ public class LocalManager implements ObjectManager {
         public NamedObjectDownloadPromise downloadByName(String name,
                                                          Consumer<Long> lengthCallback,
                                                          OutputStream output,
-                                                         int offset, long length) {
+                                                         long offset, long length) {
             List<String> ids = null;
             try {
                 ids = objectNames.get(name);


### PR DESCRIPTION
There was a typo in downloadByName API inteface, the offset parameter should be a "long", as it is in "download".

This patches is an API change but it is trivial we already implemented support for "long" offsets