### PR TITLE
Upgrade bookkeeper to 4.14.4 and enabled BookieId

### DIFF
--- a/blobit-core/pom.xml
+++ b/blobit-core/pom.xml
@@ -48,14 +48,14 @@
             </exclusions>
         </dependency>
         <dependency>
-                <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-core</artifactId>
-                <version>${libs.metricscore}</version>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${libs.metricscore}</version>
         </dependency>
         <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${libs.snappy}</version>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${libs.snappy}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>

--- a/blobit-core/src/main/java/org/blobit/core/cluster/BKLocationInfo.java
+++ b/blobit-core/src/main/java/org/blobit/core/cluster/BKLocationInfo.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
-import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.net.BookieId;
 import org.blobit.core.api.LocationInfo;
 
 /**
@@ -54,11 +54,10 @@ public class BKLocationInfo implements LocationInfo {
             return Collections.emptyList();
         }
         long entryNum = (offset + 1) / bk.entrySize;
-        List<BookieSocketAddress> ensembleAt = metadata.getEnsembleAt(entryNum);
+        List<BookieId> ensembleAt = metadata.getEnsembleAt(entryNum);
         return ensembleAt
                 .stream()
-                .map(ba -> new BKServerInfo(ba.getHostName() + ":" + ba.
-                getPort()))
+                .map((BookieId ba) -> new BKServerInfo(ba.getId()))
                 .collect(Collectors.toList());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <libs.bookkeeper>4.11.1</libs.bookkeeper>
+        <libs.bookkeeper>4.14.4</libs.bookkeeper>
         <libs.herddb>0.21.0</libs.herddb>
         <jetty.version>9.4.20.v20190813</jetty.version>
         <libs.jersey>2.29</libs.jersey>
@@ -57,7 +57,7 @@
         <libs.jcommmander>1.72</libs.jcommmander>
         <libs.spotbugsannotations>3.1.8</libs.spotbugsannotations>
         <libs.spotbugsmaven>4.0.0</libs.spotbugsmaven>
-        <libs.slf4j>1.7.29</libs.slf4j>
+        <libs.slf4j>1.7.33</libs.slf4j>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
- Upgrade to Apache BookKeeper 4.14.4
- Fix code, that now uses BookieId instead of BookieSocketAddres